### PR TITLE
Text, Image 컴포넌트 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  images: {
+    // 테스트 이미지 도메인
+    domains: ['cdn.pixabay.com']
+  }
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/pages/test/index.tsx
+++ b/pages/test/index.tsx
@@ -1,10 +1,26 @@
 import Text from '../../src/components/base/Text';
+import Image from '../../src/components/base/Image';
 
 const TestPage = () => {
   return (
-    <Text size={'01px'} color={'red'} bold>
-      hello world
-    </Text>
+    <>
+      Text 컴포넌트
+      <br />
+      <Text size={'01px'} color={'red'} bold>
+        hello world
+      </Text>
+      <br />
+      Image 컴포넌트
+      <br />
+      <Image
+        src={
+          'https://cdn.pixabay.com/photo/2018/01/14/23/12/nature-3082832__340.jpg'
+        }
+        width={200}
+        height={200}
+        round
+      />
+    </>
   );
 };
 

--- a/pages/test/index.tsx
+++ b/pages/test/index.tsx
@@ -1,0 +1,11 @@
+import Text from '../../src/components/base/Text';
+
+const TestPage = () => {
+  return (
+    <Text size={'01px'} color={'red'} bold>
+      hello world
+    </Text>
+  );
+};
+
+export default TestPage;

--- a/src/components/base/Image/index.tsx
+++ b/src/components/base/Image/index.tsx
@@ -1,0 +1,14 @@
+import { ReactElement } from 'react';
+import { StyledImageWrapper } from './styles';
+import type { ImageProps } from './types';
+import NextImage from 'next/image';
+
+const Image = ({ src, width, height, round }: ImageProps): ReactElement => {
+  return (
+    <StyledImageWrapper width={width} height={height} round={round}>
+      <NextImage src={src} layout={'fill'} />
+    </StyledImageWrapper>
+  );
+};
+
+export default Image;

--- a/src/components/base/Image/styles.ts
+++ b/src/components/base/Image/styles.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+import { ImageProps } from './types';
+
+const StyledImageWrapper = styled.div<
+  Pick<ImageProps, 'width' | 'height' | 'round'>
+>`
+  position: relative;
+  width: ${({ width }): string =>
+    typeof width === 'number' ? `${width}px` : width};
+  height: ${({ height }): string =>
+    typeof height === 'number' ? `${height}px` : height};
+  overflow: hidden;
+  border-radius: ${({ round }): string => (round ? '50%' : '0')};
+`;
+
+export { StyledImageWrapper };

--- a/src/components/base/Image/types.ts
+++ b/src/components/base/Image/types.ts
@@ -1,0 +1,8 @@
+interface ImageProps {
+  src: string;
+  width: number | string;
+  height: number | string;
+  round?: boolean;
+}
+
+export type { ImageProps };

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -1,0 +1,19 @@
+import { ReactElement } from 'react';
+import { StyledText } from './styles';
+import type { TextProps } from './types';
+
+const Text = ({
+  children,
+  size,
+  color,
+  bold,
+  block
+}: TextProps): ReactElement => {
+  return (
+    <StyledText size={size} color={color} bold={bold} block={block}>
+      {children}
+    </StyledText>
+  );
+};
+
+export default Text;

--- a/src/components/base/Text/styles.ts
+++ b/src/components/base/Text/styles.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import { TextProps } from './types';
+
+const StyledText = styled.span<TextProps>`
+  display: ${({ block }): string => (block ? 'block' : 'inline')};
+  font-size: ${({ size }): string => size};
+  font-weight: ${({ bold }): string => (bold ? 'bold' : 'normal')};
+  color: ${({ color }): string => color};
+`;
+
+export { StyledText };

--- a/src/components/base/Text/types.ts
+++ b/src/components/base/Text/types.ts
@@ -1,0 +1,12 @@
+import type { ITextSize } from '../../../types/index';
+
+interface TextProps {
+  children: string | number;
+  size: ITextSize;
+  color: string;
+  bold?: boolean;
+  italic?: boolean;
+  block?: boolean;
+}
+
+export type { TextProps };

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -1,0 +1,2 @@
+export { default as Image } from './Image';
+export { default as Text } from './Text';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './text';

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1,0 +1,7 @@
+const TEXT_SIZE = {
+  sm: '00px',
+  md: '01px',
+  lg: '02px'
+} as const;
+
+export { TEXT_SIZE };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './text';

--- a/src/types/text.ts
+++ b/src/types/text.ts
@@ -1,0 +1,6 @@
+import { TEXT_SIZE } from '../constants/index';
+
+type TextSizeKeys = keyof typeof TEXT_SIZE;
+type ITextSize = typeof TEXT_SIZE[TextSizeKeys];
+
+export type { ITextSize };


### PR DESCRIPTION
## 📝 PR 개요
base component인 Text, Image 구현
## 📸 스크린샷

## 👀 상세 내용
+ 컴포넌트 시각화 및 테스트를 위해 ```pages/test``` 디렉토리에 임시 페이지를 생성했다.
+ Text
  + Text 컴포넌트를 구현했다.
  + 관련 constants를 정의했다.
  + 관련 types를 정의했다.
+ Image
  + Image 컴포넌트를 구현했다.

## 🖐 특이 사항
+ Nextjs의 내장 Image 컴포넌트(next/image)를 styled-component로 래핑하여 컴포넌트를 만들었다.
+ 외부 도메인에서 이미지를 가져오는 경우, ```next.config.js```에 해당 도메인을 추가해야 한다.
## 🚨 이슈