### PR TITLE
ChannelCard 컴포넌트 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     // 테스트 이미지 도메인
-    domains: ['cdn.pixabay.com']
+    domains: ['cdn.pixabay.com', 'yt3.ggpht.com']
   }
 };
 

--- a/pages/test/index.tsx
+++ b/pages/test/index.tsx
@@ -1,6 +1,6 @@
 import { Text, Image, Icon } from '@/base';
 import { COLOR, FONT, ICONS } from '@/constants';
-import { Dashboard, GreetingBox, Header } from '@/domain';
+import { ChannelCard, Dashboard, GreetingBox, Header } from '@/domain';
 
 const TestPage = () => {
   const dropContent = [
@@ -34,7 +34,7 @@ const TestPage = () => {
         }
         width={200}
         height={200}
-        round
+        borderRadius={30}
       />
       <br />
       Icon 컴포넌트
@@ -62,6 +62,19 @@ const TestPage = () => {
       Header!!
       <br />
       <Header />
+      <br />
+      채널 카드
+      <br />
+      <ChannelCard
+        channelUrl={'http://www.youtube.com'}
+        direction={'vertical'}
+        size={'200px'}
+        thumbnail={
+          'https://yt3.ggpht.com/ytc/AKedOLTi6w4E6985-QdVBbovBSsnCeTETyj0WomjM5IY8Q=s900-c-k-c0x00ffffff-no-rj'
+        }
+        title={'침착맨가다나나아다다앙아다아아다아아'}
+        subTitle={'12.5'}
+      />
     </>
   );
 };

--- a/src/components/base/Image/index.tsx
+++ b/src/components/base/Image/index.tsx
@@ -3,9 +3,18 @@ import { StyledImageWrapper } from './styles';
 import type { ImageProps } from './types';
 import NextImage from 'next/image';
 
-const Image = ({ src, width, height, round }: ImageProps): ReactElement => {
+const Image = ({
+  src,
+  width,
+  height,
+  borderRadius
+}: ImageProps): ReactElement => {
   return (
-    <StyledImageWrapper width={width} height={height} round={round}>
+    <StyledImageWrapper
+      width={width}
+      height={height}
+      borderRadius={borderRadius}
+    >
       <NextImage src={src} layout={'fill'} />
     </StyledImageWrapper>
   );

--- a/src/components/base/Image/styles.ts
+++ b/src/components/base/Image/styles.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { ImageProps } from './types';
 
 const StyledImageWrapper = styled.div<
-  Pick<ImageProps, 'width' | 'height' | 'round'>
+  Pick<ImageProps, 'width' | 'height' | 'borderRadius'>
 >`
   position: relative;
   width: ${({ width }): string =>
@@ -10,7 +10,8 @@ const StyledImageWrapper = styled.div<
   height: ${({ height }): string =>
     typeof height === 'number' ? `${height}px` : height};
   overflow: hidden;
-  border-radius: ${({ round }): string => (round ? '50%' : '0')};
+  border-radius: ${({ borderRadius }): string | undefined =>
+    typeof borderRadius === 'number' ? `${borderRadius}px` : borderRadius};
 `;
 
 export { StyledImageWrapper };

--- a/src/components/base/Image/types.ts
+++ b/src/components/base/Image/types.ts
@@ -2,7 +2,7 @@ interface ImageProps {
   src: string;
   width: number | string;
   height: number | string;
-  round?: boolean;
+  borderRadius?: number | string;
 }
 
 export type { ImageProps };

--- a/src/components/domain/ChannelCard/index.tsx
+++ b/src/components/domain/ChannelCard/index.tsx
@@ -1,0 +1,37 @@
+import { ReactElement } from 'react';
+import {
+  StyledContainer,
+  StyledTextContainer,
+  StyledTextWrapper
+} from './styles';
+import type { ChannelCardProps } from './types';
+import { Image, Text } from '@/base';
+import { FONT } from '@/constants';
+import { openInNewTab } from '@/utils';
+
+const ChannelCard = ({
+  channelUrl,
+  direction,
+  size,
+  thumbnail,
+  title,
+  subTitle
+}: ChannelCardProps): ReactElement => {
+  return (
+    <StyledContainer
+      direction={direction}
+      size={size}
+      onClick={() => openInNewTab(channelUrl)}
+    >
+      <Image src={thumbnail} width={size} height={size} borderRadius={10} />
+      <StyledTextContainer direction={direction} size={size}>
+        <StyledTextWrapper>
+          <Text font={FONT.title}>{title}</Text>
+        </StyledTextWrapper>
+        <Text font={FONT.subTitle}>{`${subTitle}명`}</Text>
+      </StyledTextContainer>
+    </StyledContainer>
+  );
+};
+
+export default ChannelCard;

--- a/src/components/domain/ChannelCard/styles.ts
+++ b/src/components/domain/ChannelCard/styles.ts
@@ -1,0 +1,47 @@
+import { COLOR } from '@/constants';
+import styled from 'styled-components';
+import type { ChannelCardProps } from './types';
+
+const StyledContainer = styled.div<
+  Pick<ChannelCardProps, 'direction' | 'size'>
+>`
+  display: flex;
+  flex-direction: ${({ direction }): string =>
+    direction === 'parallel' ? 'row' : 'column'};
+  width: ${({ direction, size }): string =>
+    direction === 'parallel'
+      ? '100%'
+      : typeof size === 'number'
+      ? `${size}px`
+      : size};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${COLOR.whiteGray};
+  }
+`;
+
+const StyledTextContainer = styled.div<
+  Pick<ChannelCardProps, 'direction' | 'size'>
+>`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: ${({ direction, size }): string =>
+    direction === 'parallel'
+      ? '300px'
+      : typeof size === 'number'
+      ? `${size}px`
+      : size};
+  ${({ direction }) =>
+    direction === 'parallel' ? { marginLeft: '10px' } : { marginTop: '7px' }}
+  padding: 0 5px;
+`;
+
+const StyledTextWrapper = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export { StyledContainer, StyledTextContainer, StyledTextWrapper };

--- a/src/components/domain/ChannelCard/types.ts
+++ b/src/components/domain/ChannelCard/types.ts
@@ -1,0 +1,12 @@
+import type { ICard } from '@/types';
+
+interface ChannelCardProps {
+  channelUrl: string;
+  direction?: 'vertical' | 'parallel';
+  size: ICard;
+  thumbnail: string;
+  title: string;
+  subTitle: string;
+}
+
+export type { ChannelCardProps };

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -1,3 +1,4 @@
+export { default as ChannelCard } from './ChannelCard';
 export { default as Dashboard } from './Dashboard';
 export { default as GreetingBox } from './GreetingBox';
 export { default as Header } from './Header';

--- a/src/constants/channelCard.ts
+++ b/src/constants/channelCard.ts
@@ -1,0 +1,7 @@
+const CARD = {
+  small: '70px',
+  medium: '150px',
+  large: '200px'
+} as const;
+
+export { CARD };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './button';
+export * from './channelCard';
 export * from './color';
 export * from './dropdown';
 export * from './icon';

--- a/src/types/channelCard.ts
+++ b/src/types/channelCard.ts
@@ -1,0 +1,6 @@
+import { CARD } from '@/constants';
+
+type CardKeys = keyof typeof CARD;
+type ICard = typeof CARD[CardKeys];
+
+export type { ICard };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './button';
+export * from './channelCard';
 export * from './color';
 export * from './dropdown';
 export * from './icon';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './openInNewTab';

--- a/src/utils/openInNewTab.ts
+++ b/src/utils/openInNewTab.ts
@@ -1,0 +1,1 @@
+export const openInNewTab = (url: string): Window | null => window.open(url);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -191,7 +191,7 @@ table {
   border-spacing: 0;
   border-collapse: collapse;
 }
-body {
+* {
   box-sizing: border-box;
   letter-spacing: -0.05em;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       "@/base": ["src/components/base"],
       "@/domain": ["src/components/domain"],
       "@/constants": ["src/constants"],
-      "@/types": ["src/types"]
+      "@/types": ["src/types"],
+      "@/utils": ["src/utils"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
## 📝 PR 개요
domain component인 ChannelCard 구현
## 📸 스크린샷
<img width="206" alt="스크린샷 2022-02-27 오후 2 47 26" src="https://user-images.githubusercontent.com/75300807/155870500-c92dac8c-a8e0-4264-9eb7-6fce66f2548a.png">
<img width="367" alt="스크린샷 2022-02-27 오후 2 47 01" src="https://user-images.githubusercontent.com/75300807/155870506-c597542f-79da-433d-9bc3-f4bc65dbd6c4.png">



## 👀 상세 내용
+ ```direction``` prop을 통해 가로형 또는 세로형 선택 가능 (기본은 세로)
+ 70x70, 150x150, 200x200의 세 가지 크기 선택 가능
## 🖐 특이 사항
+ ```StyledTextContainer```를 base/Text 컴포넌트를 extend 하여 만들려고 했으나, base/Text 컴포넌트가 styled component가 아닌 jsx를 반환하는 컴포넌트이기 때문에 불가능한듯.
## 🚨 이슈
+ 구독자수 api 확립 이후 해당 부분 로직 추가 필요