### PR TITLE
domain/Carousel 컴포넌트 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     // 테스트 이미지 도메인
-    domains: ['cdn.pixabay.com', 'yt3.ggpht.com']
+    domains: ['cdn.pixabay.com', 'yt3.ggpht.com', 'via.placeholder.com']
   }
 };
 

--- a/pages/test/index.tsx
+++ b/pages/test/index.tsx
@@ -1,6 +1,12 @@
 import { Text, Image, Icon } from '@/base';
 import { COLOR, FONT, ICONS } from '@/constants';
-import { ChannelCard, Dashboard, GreetingBox, Header } from '@/domain';
+import {
+  Carousel,
+  ChannelCard,
+  Dashboard,
+  GreetingBox,
+  Header
+} from '@/domain';
 
 const TestPage = () => {
   const dropContent = [
@@ -75,6 +81,10 @@ const TestPage = () => {
         title={'침착맨가다나나아다다앙아다아아다아아'}
         subTitle={'12.5'}
       />
+      <br />
+      캐러셀 슬라이드
+      <br />
+      <Carousel />
     </>
   );
 };

--- a/src/components/base/Image/index.tsx
+++ b/src/components/base/Image/index.tsx
@@ -4,7 +4,7 @@ import type { ImageProps } from './types';
 import NextImage from 'next/image';
 
 const Image = ({
-  src,
+  src = 'https://via.placeholder.com/200?text=No+Image',
   width,
   height,
   borderRadius

--- a/src/components/base/Image/types.ts
+++ b/src/components/base/Image/types.ts
@@ -1,5 +1,5 @@
 interface ImageProps {
-  src: string;
+  src?: string;
   width: number | string;
   height: number | string;
   borderRadius?: number | string;

--- a/src/components/base/Text/types.ts
+++ b/src/components/base/Text/types.ts
@@ -3,7 +3,7 @@ import { ReactChild } from 'react';
 
 interface TextProps {
   children?: ReactChild;
-  size: IFont;
+  font: IFont;
   color?: IColor;
   bold?: boolean;
   italic?: boolean;

--- a/src/components/domain/Carousel/index.tsx
+++ b/src/components/domain/Carousel/index.tsx
@@ -1,0 +1,73 @@
+import { ReactElement, useEffect, useRef, Children } from 'react';
+import { StyledContainer } from './styles';
+import { ChannelCard } from '@/domain';
+import Link from 'next/link';
+
+// DUMMY
+const channel = {
+  url: 'http://www.youtube.com',
+  thumbnail:
+    'https://yt3.ggpht.com/ytc/AKedOLTi6w4E6985-QdVBbovBSsnCeTETyj0WomjM5IY8Q=s900-c-k-c0x00ffffff-no-rj',
+  title: '침착맨',
+  subTitle: '11.1'
+};
+
+const Carousel = (): ReactElement => {
+  // from store.
+  // top 10 channels
+  // IChannel 타입 필요
+  let topChannels = [
+    channel,
+    channel,
+    channel,
+    channel,
+    channel,
+    channel,
+    channel,
+    channel
+  ];
+
+  const wheelRef = useRef<HTMLDivElement>(null);
+
+  const handleWheel = (event: WheelEvent): void => {
+    event.preventDefault();
+    if (wheelRef.current) {
+      if (
+        wheelRef.current.scrollLeft + event.deltaY < 0 ||
+        wheelRef.current.scrollLeft + event.deltaY >
+          wheelRef.current.offsetWidth
+      )
+        return;
+
+      wheelRef.current.scrollLeft += event.deltaY;
+    }
+  };
+
+  useEffect(() => {
+    wheelRef.current?.addEventListener('wheel', handleWheel);
+    return () => wheelRef.current?.removeEventListener('wheel', handleWheel);
+  });
+
+  return (
+    <StyledContainer ref={wheelRef}>
+      {Children.toArray(
+        topChannels.map((channel) => (
+          <ChannelCard
+            url={channel.url}
+            size={'150px'}
+            thumbnail={channel.thumbnail}
+            title={channel.title}
+            subTitle={channel.subTitle}
+          />
+        ))
+      )}
+      <Link href={'/list'}>
+        <a>
+          <ChannelCard size={'150px'} />
+        </a>
+      </Link>
+    </StyledContainer>
+  );
+};
+
+export default Carousel;

--- a/src/components/domain/Carousel/styles.ts
+++ b/src/components/domain/Carousel/styles.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+// snap not working?
+// temp size
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  width: 700px;
+  overflow-x: scroll;
+  scroll-snap-type: x mandatory;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const StyledMoreButton = styled.button`
+  display: inline-block;
+  height: 150px;
+  padding: 15px;
+  background-color: red;
+  border: none;
+`;
+
+export { StyledContainer, StyledMoreButton };

--- a/src/components/domain/ChannelCard/index.tsx
+++ b/src/components/domain/ChannelCard/index.tsx
@@ -10,7 +10,7 @@ import { FONT } from '@/constants';
 import { openInNewTab } from '@/utils';
 
 const ChannelCard = ({
-  channelUrl,
+  url,
   direction,
   size,
   thumbnail,
@@ -21,7 +21,7 @@ const ChannelCard = ({
     <StyledContainer
       direction={direction}
       size={size}
-      onClick={() => openInNewTab(channelUrl)}
+      onClick={() => openInNewTab(url)}
     >
       <Image src={thumbnail} width={size} height={size} borderRadius={10} />
       <StyledTextContainer direction={direction} size={size}>

--- a/src/components/domain/ChannelCard/index.tsx
+++ b/src/components/domain/ChannelCard/index.tsx
@@ -28,7 +28,9 @@ const ChannelCard = ({
         <StyledTextWrapper>
           <Text font={FONT.title}>{title}</Text>
         </StyledTextWrapper>
-        <Text font={FONT.subTitle}>{`${subTitle}명`}</Text>
+        <Text font={FONT.subTitle}>
+          {subTitle !== undefined ? `${subTitle}명` : ''}
+        </Text>
       </StyledTextContainer>
     </StyledContainer>
   );

--- a/src/components/domain/ChannelCard/types.ts
+++ b/src/components/domain/ChannelCard/types.ts
@@ -1,12 +1,12 @@
 import type { ICard } from '@/types';
 
 interface ChannelCardProps {
-  channelUrl: string;
+  channelUrl?: string;
   direction?: 'vertical' | 'parallel';
   size: ICard;
-  thumbnail: string;
-  title: string;
-  subTitle: string;
+  thumbnail?: string;
+  title?: string;
+  subTitle?: string;
 }
 
 export type { ChannelCardProps };

--- a/src/components/domain/ChannelCard/types.ts
+++ b/src/components/domain/ChannelCard/types.ts
@@ -1,7 +1,7 @@
 import type { ICard } from '@/types';
 
 interface ChannelCardProps {
-  channelUrl?: string;
+  url?: string;
   direction?: 'vertical' | 'parallel';
   size: ICard;
   thumbnail?: string;

--- a/src/components/domain/Dashboard/LinkText/index.tsx
+++ b/src/components/domain/Dashboard/LinkText/index.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react';
 import Link from 'next/link';
 import { Text } from '@/base';
-import { StyledLinkText, StyledA } from './styles';
+import { StyledLinkText } from './styles';
 import { LinkTextProps } from './types';
 
 const LinkText = ({
@@ -13,11 +13,11 @@ const LinkText = ({
   return (
     <StyledLinkText>
       <Link href={url}>
-        <StyledA>
+        <a>
           <Text font={textFont} color={textColor} bold>
             {children}
           </Text>
-        </StyledA>
+        </a>
       </Link>
     </StyledLinkText>
   );

--- a/src/components/domain/Dashboard/LinkText/styles.ts
+++ b/src/components/domain/Dashboard/LinkText/styles.ts
@@ -5,9 +5,4 @@ const StyledLinkText = styled.div`
   width: 100%;
 `;
 
-const StyledA = styled.a`
-  text-decoration: none;
-  cursor: pointer;
-`;
-
-export { StyledLinkText, StyledA };
+export { StyledLinkText };

--- a/src/components/domain/Header/index.tsx
+++ b/src/components/domain/Header/index.tsx
@@ -26,7 +26,7 @@ const Header = (): ReactElement => {
       <Link href={'#'}>
         <a>
           <StyledLogo>
-            <Icon icon={'bookmark'} size={ICON_SIZE.lg} />
+            <Icon icon={'star'} size={ICON_SIZE.lg} />
           </StyledLogo>
         </a>
       </Link>

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -1,3 +1,4 @@
+export { default as Carousel } from './Carousel';
 export { default as ChannelCard } from './ChannelCard';
 export { default as Dashboard } from './Dashboard';
 export { default as GreetingBox } from './GreetingBox';

--- a/src/utils/openInNewTab.ts
+++ b/src/utils/openInNewTab.ts
@@ -1,1 +1,2 @@
-export const openInNewTab = (url: string): Window | null => window.open(url);
+export const openInNewTab = (url: string | undefined): Window | null =>
+  window.open(url);

--- a/src/utils/openInNewTab.ts
+++ b/src/utils/openInNewTab.ts
@@ -1,2 +1,2 @@
-export const openInNewTab = (url: string | undefined): Window | null =>
-  window.open(url);
+export const openInNewTab = (url: string | undefined): Window | null | false =>
+  url !== undefined && window.open(url);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -197,5 +197,6 @@ table {
 }
 button,
 a {
+  text-decoration: none;
   cursor: pointer;
 }


### PR DESCRIPTION
## 📝 PR 개요
domain component인 Carousel 구현
## 📸 스크린샷
<img width="705" alt="스크린샷 2022-03-02 오후 11 40 52" src="https://user-images.githubusercontent.com/75300807/156383718-1311fbdf-f24e-495d-82cc-2e69e32cf1df.png">

## 👀 상세 내용
+ 🚩 컴포넌트에서 상위 10개 채널 정보를 스토어로부터 가져온다.
+ 해당 채널을 클릭하면 새탭에서 채널 홈이 열린다.
+ Ref를 사용하여 container 요소에서 휠을 통해 좌우 스크롤이 가능하다.
+ 마지막 카드를 클릭하면 전체 리스트 페이지로 이동된다.
## 🖐 특이 사항
+ 추후 다른 곳에서 wheel 이벤트를 사용하게 된다면 useWheel hook을 따로 만들어 재사용 하자.
## 🚨 이슈
+ 정확한 크기 및 디자인 미확립