### PR TITLE
유저가 공유한 리스트 페이지 초기 구현

### DIFF
--- a/pages/list/[listId]/index.tsx
+++ b/pages/list/[listId]/index.tsx
@@ -1,0 +1,31 @@
+import { IChannel } from '@/types';
+import { useRouter } from 'next/router';
+import { ReactElement } from 'react';
+
+export async function getServerSideProps() {
+  const router = useRouter();
+  const { listId } = router.query;
+  // const channels = dispatch(getListId의리스트채널)
+  const DUMMY_CHANNELS = [] as IChannel[];
+  return {
+    props: {
+      channels: DUMMY_CHANNELS
+    }
+  };
+}
+
+const PublicSharedPage = ({
+  channels
+}: {
+  channels: IChannel[];
+}): ReactElement => {
+  return (
+    <>
+      {
+        // channels.map(channle => 'Channel Item')
+      }
+    </>
+  );
+};
+
+export default PublicSharedPage;

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,1 +1,2 @@
 export { default as authApi } from './auth';
+export { default as publicListApi } from './publicList';

--- a/src/apis/publicList/index.ts
+++ b/src/apis/publicList/index.ts
@@ -1,0 +1,12 @@
+// 추후 /apis/list와 통합 여부 검토 필요
+
+import { IChannel } from '@/types';
+import { request } from '../axios';
+
+const publicListApi = {
+  getListSummary: () => {},
+  getFullList: (id: number | string): Promise<IChannel> =>
+    request.get(`/api/list/detail/${id}`)
+};
+
+export default publicListApi;


### PR DESCRIPTION
## 📝 PR 개요
유저가 생성한 리스트 페이지 링크를 통해 들어올 경우 보여지는 SSR 페이지 구현하기
## 📸 스크린샷

## 👀 상세 내용
+ SSR 페이지 (요청 시 pre-render)
+ ```getServerSideProps``` 함수 + useRouter의 query로 listId를 파싱하여 해당하는 list 데이터 요청
+ Next.js Dynamic Routing 사용
## 🖐 특이 사항
+ ```getServerSideProps``` 함수 내부에서 Redux dispatch 사용 필요 -> Next-redux-wrapper의 Hydrate 필요
  + 서버에서 생성된 store와 클라이언트에서 생성될 store를 Hydrate를 통해 통합한다.
  + rootReducer에 Hydrate Action 처리 로직 구현 필요
+ 렌더링 될 리스트 아이템 컴포넌트 추가 구현 필요
+ 채널 정보 외, 생성자(author) 정보 받아오는 로직 추가 필요
## 🚨 이슈
